### PR TITLE
Add past years section

### DIFF
--- a/archive-event.php
+++ b/archive-event.php
@@ -12,6 +12,8 @@ get_header();
 
 <?php get_template_part('partials/archive-event/schedule'); ?>
 
+<?php get_template_part('partials/past-years'); ?>
+
 <!-- end main-content -->
 
 </main>

--- a/archive-exhibitor.php
+++ b/archive-exhibitor.php
@@ -30,9 +30,7 @@ if ($publish_exhibitors == 'on') {
 }
 ?>
 
-<?php
-// LINKS TO PAST EDITIONS WILL GO HERE
-?>
+<?php get_template_part('partials/past-years'); ?>
 
 <!-- end main-content -->
 

--- a/archive-exhibitor.php
+++ b/archive-exhibitor.php
@@ -5,6 +5,7 @@ $publish_exhibitors = IGV_get_option('_igv_page_options', '_igv_publish_exhibito
 $exhibitors_apply_text = IGV_get_option('_igv_page_options', '_igv_exhibitors_apply_text');
 $apply_url = IGV_get_option('_igv_site_options', '_igv_apply_url');
 $apply_end = IGV_get_option('_igv_site_options', '_igv_apply_end');
+$current_year_id = IGV_get_option('_igv_site_options', '_igv_current_fair_year');
 ?>
 
 <!-- main content -->
@@ -19,7 +20,7 @@ $apply_end = IGV_get_option('_igv_site_options', '_igv_apply_end');
 // if the application hasn't ended and 
 // exhibitors are not published, 
 // show the Apply Now section
-if ($publish_exhibitors == 'on') { 
+if (($current_year_id == get_fair_year_id() && $publish_exhibitors == 'on') || $current_year_id != $fair_year_id) {
 
   get_template_part('partials/archive-exhibitor/exhibitors');
 

--- a/archive-press.php
+++ b/archive-press.php
@@ -14,9 +14,7 @@ get_header();
 
 <?php get_template_part('partials/archive-press/photo-gallery'); ?>
 
-<?php
-// LINKS TO PAST EDITIONS WILL GO HERE
-?>
+<?php get_template_part('partials/past-years'); ?>
 
 <!-- end main-content -->
 

--- a/lib/functions-filters.php
+++ b/lib/functions-filters.php
@@ -31,15 +31,16 @@ function exclude_past_exhibitors( $query ) {
     $query->set( 'orderby', 'title' );
     $query->set( 'order', 'ASC' );
 
-    $current_year_id = IGV_get_option('_igv_site_options', '_igv_current_fair_year');
-    $taxquery = array(
-      array(
-        'taxonomy' => 'fair_year',
-        'field' => 'term_id',
-        'terms' => $current_year_id,
-      )
-    );
-    $query->set( 'tax_query', $taxquery );
+    if (get_fair_year_id()) {
+      $taxquery = array(
+        array(
+          'taxonomy' => 'fair_year',
+          'field' => 'term_id',
+          'terms' => get_fair_year_id(),
+        )
+      );
+      $query->set( 'tax_query', $taxquery );
+    }
   }
 }
 add_action( 'pre_get_posts', 'exclude_past_exhibitors' );
@@ -48,9 +49,6 @@ add_action( 'pre_get_posts', 'exclude_past_exhibitors' );
 // Only return non-highlight, current year press for archive
 function filter_press_posts( $query ) {
   if ( $query->is_main_query() && is_post_type_archive('press') && !is_admin() ) {
-
-    $current_year_id = IGV_get_option('_igv_site_options', '_igv_current_fair_year');
-
 
     //add metaquery for highlight posts
     $highlight_metaquery = array( 
@@ -78,58 +76,20 @@ function filter_press_posts( $query ) {
     $query->set( 'post__not_in', $highlight_ids );
 
 
-
-    //posts with current year
-    $taxquery = array(
-      array(
-        'taxonomy' => 'fair_year',
-        'field' => 'term_id',
-        'terms' => $current_year_id,
-      ),
-    );
-    //get non-highlight, current year posts
-    $args = array(
-      'post_type' => 'press',
-      'tax_query' => $taxquery,
-      'post__not_in' => $highlight_ids
-    );
-    $current_year_posts = get_posts($args);
-
-
-    //if there are more than 2 current posts
-    //exclude all others from query
-    if (count($current_year_posts) > 2) {
-      $query->set( 'tax_query', $taxquery );
-    }
-  }
-}
-add_action( 'pre_get_posts', 'filter_press_posts' );
-
-// Only return current year events for archive, and order results by start date
-function filter_event_posts( $query ) {
-  if ( $query->is_main_query() && is_post_type_archive('event') && !is_admin() ) {
-
-    $current_year_id = IGV_get_option('_igv_site_options', '_igv_current_fair_year');
-
-    $query->set( 'meta_key', '_igv_event_start' );
-    $query->set( 'orderby', 'meta_value_num' );
-    $query->set( 'order', 'ASC' );
-
-
-    if (!empty($current_year_id)) {
-
+    if (get_fair_year_id()) {
       //posts with current year
       $taxquery = array(
         array(
           'taxonomy' => 'fair_year',
           'field' => 'term_id',
-          'terms' => $current_year_id,
+          'terms' => get_fair_year_id(),
         ),
       );
       //get non-highlight, current year posts
       $args = array(
-        'post_type' => 'event',
+        'post_type' => 'press',
         'tax_query' => $taxquery,
+        'post__not_in' => $highlight_ids
       );
       $current_year_posts = get_posts($args);
 
@@ -139,8 +99,75 @@ function filter_event_posts( $query ) {
       if (count($current_year_posts) > 2) {
         $query->set( 'tax_query', $taxquery );
       }
+    }
+  }
+}
+add_action( 'pre_get_posts', 'filter_press_posts' );
 
+// Only return current year events for archive, and order results by start date
+function filter_event_posts( $query ) {
+  if ( $query->is_main_query() && is_post_type_archive('event') && !is_admin() ) {
+    $query->set( 'meta_key', '_igv_event_start' );
+    $query->set( 'orderby', 'meta_value_num' );
+    $query->set( 'order', 'ASC' );
+
+    if (get_fair_year_id()) {
+      //posts with current year
+      $taxquery = array(
+        array(
+          'taxonomy' => 'fair_year',
+          'field' => 'term_id',
+          'terms' => get_fair_year_id(),
+        ),
+      );
+      //get non-highlight, current year posts
+      $args = array(
+        'post_type' => 'event',
+        'tax_query' => $taxquery,
+      );
+      $current_year_posts = get_posts($args);
+
+      //if there are more than 2 current posts
+      //exclude all others from query
+      if (count($current_year_posts) > 2) {
+        $query->set( 'tax_query', $taxquery );
+      }
     }
   }
 }
 add_action( 'pre_get_posts', 'filter_event_posts' );
+
+/**
+ * Extend get terms with post type parameter.
+ *
+ * @global $wpdb
+ * @param string $clauses
+ * @param string $taxonomy
+ * @param array $args
+ * @return string
+ */
+function df_terms_clauses( $clauses, $taxonomy, $args ) {
+  if ( isset( $args['post_type'] ) && ! empty( $args['post_type'] ) && $args['fields'] !== 'count' ) {
+    global $wpdb;
+
+    $post_types = array();
+
+    if ( is_array( $args['post_type'] ) ) {
+      foreach ( $args['post_type'] as $cpt ) {
+        $post_types[] = "'" . $cpt . "'";
+      }
+    } else {
+      $post_types[] = "'" . $args['post_type'] . "'";
+    }
+
+    if ( ! empty( $post_types ) ) {
+      $clauses['fields'] = 'DISTINCT ' . str_replace( 'tt.*', 'tt.term_taxonomy_id, tt.taxonomy, tt.description, tt.parent', $clauses['fields'] ) . ', COUNT(p.post_type) AS count';
+      $clauses['join'] .= ' LEFT JOIN ' . $wpdb->term_relationships . ' AS r ON r.term_taxonomy_id = tt.term_taxonomy_id LEFT JOIN ' . $wpdb->posts . ' AS p ON p.ID = r.object_id';
+      $clauses['where'] .= ' AND (p.post_type IN (' . implode( ',', $post_types ) . ') OR p.post_type IS NULL)';
+      $clauses['orderby'] = 'GROUP BY t.term_id ' . $clauses['orderby'];
+    }
+  }
+  return $clauses;
+}
+
+add_filter( 'terms_clauses', 'df_terms_clauses', 10, 3 );

--- a/lib/functions-utility.php
+++ b/lib/functions-utility.php
@@ -56,3 +56,23 @@ function debug_page_request() {
   echo ' -->'.D4P_EOL;
 }
 
+// Gets the term ID for the fair year being viewed. 
+// If no current fair year set, or no fair_year query var, returns false
+// For use on Exhibitors, Program, and Press archive pages
+function get_fair_year_id() {
+  if (!empty(get_query_var('fair_year'))) {
+    $year = get_query_var('fair_year');
+    $year_term = get_term_by('slug', $year, 'fair_year');
+    
+    if ($year_term) {
+      $year_id = $year_term->term_id;
+    } else {
+      $year_id = false;
+    }
+  } elseif (!empty(IGV_get_option('_igv_site_options', '_igv_current_fair_year'))) {
+    $year_id = IGV_get_option('_igv_site_options', '_igv_current_fair_year');
+  } else {
+    $year_id = false;
+  }
+  return $year_id;
+}

--- a/partials/archive-event/highlights.php
+++ b/partials/archive-event/highlights.php
@@ -1,12 +1,9 @@
 <?php
+$fair_year_id = get_fair_year_id();
 $current_year_id = IGV_get_option('_igv_site_options', '_igv_current_fair_year');
-$current_year = (!empty($current_year_id)) ? get_term($current_year_id)->slug : false; 
-// if we have the term ID, get the slug, 
-// otherwise set it false for later conditionals
-
 $publish_program = IGV_get_option('_igv_page_options', '_igv_publish_program');
 
-if ($publish_program == 'on') {
+if (($current_year_id == get_fair_year_id() && $publish_program == 'on') || $current_year_id != $fair_year_id) {
 
   $args = array (
     'post_type'       => 'event',
@@ -26,7 +23,7 @@ if ($publish_program == 'on') {
       array(
         'taxonomy' => 'fair_year',
         'field' => 'term_id',
-        'terms' => $current_year_id, // get posts with current year
+        'terms' => $fair_year_id, // get posts with current year
       )
     ),
   );

--- a/partials/archive-event/schedule.php
+++ b/partials/archive-event/schedule.php
@@ -1,12 +1,9 @@
 <?php
 $current_year_id = IGV_get_option('_igv_site_options', '_igv_current_fair_year');
-$current_year = (!empty($current_year_id)) ? get_term($current_year_id)->slug : false; 
-// if we have the term ID, get the slug, 
-// otherwise set it false for later conditionals
-
 $publish_program = IGV_get_option('_igv_page_options', '_igv_publish_program');
 
-if ($publish_program == 'on') {
+if (($current_year_id == get_fair_year_id() && $publish_program == 'on') || $current_year_id != get_fair_year_id()) {
+
   if( have_posts() ) {
 ?>
 <section class="section section-yellow">

--- a/partials/archive-exhibitor/committee.php
+++ b/partials/archive-exhibitor/committee.php
@@ -1,8 +1,9 @@
 <?php 
+$fair_year_id = get_fair_year_id();
 $current_year_id = IGV_get_option('_igv_site_options', '_igv_current_fair_year');
 $publish_committee = IGV_get_option('_igv_page_options', '_igv_publish_committee');
 
-if ( $publish_committee && !empty($current_year_id)) {
+if (($current_year_id == get_fair_year_id() && $publish_committee == 'on') || $current_year_id != get_fair_year_id()) {
 
   $args = array (
     'post_type'       => 'committee',
@@ -11,7 +12,7 @@ if ( $publish_committee && !empty($current_year_id)) {
       array(
         'taxonomy' => 'fair_year',
         'field' => 'term_id',
-        'terms' => $current_year_id, // get posts with current year
+        'terms' => $fair_year_id, // get posts with current year
       )
     ),
     'orderby'         => 'title',

--- a/partials/archive-press/photo-gallery.php
+++ b/partials/archive-press/photo-gallery.php
@@ -1,22 +1,19 @@
 <?php 
 
-$current_year_id = IGV_get_option('_igv_site_options', '_igv_current_fair_year');
-$current_year = !empty($current_year_id) ? get_term($current_year_id)->slug : false; 
+$fair_year_id = get_fair_year_id();
 
+if ($fair_year_id) {
 $args = array (
   'post_type' => 'photo_gallery',
   'numberposts' => '-1',
-);
-
-if (!empty($current_year_id)) {
-  $args['tax_query'] = array(
+  'tax_query' => array(
     array(
       'taxonomy' => 'fair_year',
       'field' => 'term_id',
-      'terms' => $current_year_id,
+      'terms' => $fair_year_id,
     ),
-  );
-}
+  ),
+);
 
 $photo_galleries = new WP_Query( $args );
 
@@ -52,5 +49,8 @@ if ( $photo_galleries->have_posts() ) {
     </div>
   </section>
 <?php
-  }
+}
+
+wp_reset_postdata();
+}
 ?>

--- a/partials/past-years.php
+++ b/partials/past-years.php
@@ -1,0 +1,38 @@
+<?php
+$fair_year_id = get_fair_year_id();
+$post_type = get_post_type();
+
+$other_years = get_terms(array(
+  'taxonomy' => 'fair_year',
+  'exclude' => $fair_year_id,
+  'hide_empty' => true,
+  'orderby' => 'name',
+  'order' => 'desc',
+  'post_type' => array($post_type,),
+));
+
+if (!empty($other_years)) {
+?>
+<section class="section">
+  <div class="container">
+    <div class="row">
+      <div class="col col-l col-l-12">
+        <h2><?php _e('[:en]Other Editions[:es]Otras ediciónes'); ?></h2>
+      </div>
+    </div>
+    <div class="row"> 
+<?php
+  foreach ($other_years as $year) {
+?>
+      <a href="<?php echo get_post_type_archive_link($post_type) . '?fair_year=' . $year->slug; ?>" class="col col-l col-l-2 flex-row justify-center align-center">
+        <div class="button font-size-h2 font-sans"><?php echo $year->name; ?></div>
+      </a>
+<?php
+  }
+?>
+    </div>
+  </div>
+</section>
+<?php 
+} 
+?>

--- a/partials/past-years.php
+++ b/partials/past-years.php
@@ -25,7 +25,7 @@ if (!empty($other_years)) {
   foreach ($other_years as $year) {
 ?>
       <a href="<?php echo get_post_type_archive_link($post_type) . '?fair_year=' . $year->slug; ?>" class="col col-l col-l-2 flex-row justify-center align-center">
-        <div class="button font-size-h2 font-sans"><?php echo $year->name; ?></div>
+        <div class="button font-size-h2 font-sans"><?php echo $year->slug; ?></div>
       </a>
 <?php
   }


### PR DESCRIPTION
adds get_fair_year_id() utility function.
// Gets the term ID for the fair year being viewed. 
// If no current fair year set, or no fair_year query var, returns false
// For use on Exhibitors, Program, and Press archive pages
